### PR TITLE
implement multithreading[wip]

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,2 +1,2 @@
-project('aa_pokerhands', 'c', version: '0.04.1-dev')
+project('aa_pokerhands', 'c', version: '0.1.0.555', default_options: 'warning_level=2')
 subdir('src')

--- a/src/aa-pokerhands.c
+++ b/src/aa-pokerhands.c
@@ -62,7 +62,7 @@ main_thread(void *arg) {
 
   int run_count = 0;
 
-  bool final[RANKS];
+  bool final_hand[RANKS];
 
   /* Start main program loop */
   while (run_count++ < tinfo->RUN_COUNT)
@@ -101,7 +101,7 @@ main_thread(void *arg) {
     st_hand hand;
 
     int hand_seq[ACE_HIGH];
-    zero (hand_seq, final, hand_suits);
+    zero (hand_seq, final_hand, hand_suits);
 
     /* Deal out a hand */
 
@@ -187,7 +187,7 @@ main_thread(void *arg) {
     }
 
     /* Evaluate the hand */
-    short paired = find_matches (hand_seq, final);
+    short paired = find_matches (hand_seq, final_hand);
 
     /* if no matches were found, check for flush and straight
      * if there were any matches, flush or straight is impossible,
@@ -197,11 +197,11 @@ main_thread(void *arg) {
 
     if (!paired)
     {
-      isStraight (hand_seq, &isHighStraight, final);
-      isFlush (final, hand_suits);
+      isStraight (hand_seq, &isHighStraight, final_hand);
+      isFlush (final_hand, hand_suits);
     }
 
-    hand_eval (tinfo->totals, ranks, isHighStraight, final);
+    hand_eval (tinfo->totals, ranks, isHighStraight, final_hand);
   }
 
   return NULL;
@@ -242,7 +242,8 @@ main (int argc, char *argv[])
   for (i = 0; i < RANKS; i++)
       totals[i] = 0;
 
-  int num_threads = 2;
+  // increasing this to a value of > 1 results in an ~8x slowdown
+  int num_threads = 1;
   st_deck_dh deck[num_threads];
 
   for (i = 0; i < num_threads; i++)

--- a/src/aa-pokerhands.c
+++ b/src/aa-pokerhands.c
@@ -65,8 +65,6 @@ main_thread(void *arg) {
 
   int run_count = 0;
 
-  bool final_hand[RANKS];
-
   /* Start main program loop */
   while (run_count++ < tinfo->RUN_COUNT)
   {
@@ -75,6 +73,7 @@ main_thread(void *arg) {
 
     deck_shuffle_dh (tinfo->deck);
 
+    bool final_hand[RANKS];
     int hand_seq[ACE_HIGH];
     short int hand_suits[NUM_OF_SUITS];
     init (hand_seq, final_hand, hand_suits);
@@ -182,7 +181,7 @@ main_thread(void *arg) {
 
       /* if hand.card[i].suit == 2 (Spades), then hand_suits[2] will
        * be incremented. If hand_suits[2] == 5, a flush will be
-       * found when isFlush() is called.    */
+       * found when is_flush() is called.    */
 
       int suitn = hand.card[i].suit;
       hand_suits[suitn]++;
@@ -200,7 +199,7 @@ main_thread(void *arg) {
     if (!paired)
     {
       isStraight (hand_seq, &isHighStraight, final_hand);
-      isFlush (final_hand, hand_suits);
+      final_hand[FLUSH] = is_flush (hand_suits);
     }
 
     hand_eval (tinfo->totals, ranks, isHighStraight, final_hand);
@@ -250,7 +249,6 @@ main (int argc, char *argv[])
     deck_init_dh (&deck[i]);
 
   int s;
-  struct thread_info *tinfo;
   pthread_attr_t attr;
 
   // How to calculate the needed stack size?
@@ -260,7 +258,7 @@ main (int argc, char *argv[])
 
   pthread_attr_init(&attr);
   pthread_attr_setstacksize(&attr, stack_size);
-  tinfo = calloc(num_threads, sizeof(struct thread_info));
+  struct thread_info *tinfo = calloc(num_threads, sizeof(struct thread_info));
   if (tinfo == NULL)
     puts("Unable to allocate memory");
 

--- a/src/aa-pokerhands.c
+++ b/src/aa-pokerhands.c
@@ -29,6 +29,9 @@
 #include "functions.h"
 #include <pthread.h>
 
+// FIXME: Increasing this to a value of > 1 results in an ~8x slowdown
+#define num_threads 1
+
 const char *ranks[] = {
   "Pair",
   "Two Pair",
@@ -70,9 +73,11 @@ main_thread(void *arg) {
     int i = 0;
     int j, k = i;
 
-    short int hand_suits[NUM_OF_SUITS];
-
     deck_shuffle_dh (tinfo->deck);
+
+    int hand_seq[ACE_HIGH];
+    short int hand_suits[NUM_OF_SUITS];
+    init (hand_seq, final_hand, hand_suits);
 
     if (MORE_OUTPUT)
     {
@@ -99,9 +104,6 @@ main_thread(void *arg) {
 
     /* +4 for the unimplemented PLAY feature */
     st_hand hand;
-
-    int hand_seq[ACE_HIGH];
-    zero (hand_seq, final_hand, hand_suits);
 
     /* Deal out a hand */
 
@@ -242,8 +244,6 @@ main (int argc, char *argv[])
   for (i = 0; i < RANKS; i++)
       totals[i] = 0;
 
-  // increasing this to a value of > 1 results in an ~8x slowdown
-  int num_threads = 1;
   st_deck_dh deck[num_threads];
 
   for (i = 0; i < num_threads; i++)

--- a/src/aa-pokerhands.c
+++ b/src/aa-pokerhands.c
@@ -202,7 +202,10 @@ main_thread(void *arg) {
       final_hand[FLUSH] = is_flush (hand_suits);
     }
 
+    pthread_mutex_t lock;
+    pthread_mutex_lock(&lock);
     hand_eval (tinfo->totals, ranks, isHighStraight, final_hand);
+    pthread_mutex_unlock(&lock);
   }
 
   return NULL;

--- a/src/aa-pokerhands.h
+++ b/src/aa-pokerhands.h
@@ -1,7 +1,7 @@
 /*
  * aa-pokerhands.h
  *
- * Copyright 2011-2020 Andy Alt <andy400-dev@yahoo.com>
+ * Copyright 2011-2021 Andy Alt <andy400-dev@yahoo.com>
  * This file is part of aa-pokerhands
  * <https://github.com/theimpossibleastronaut/aa-pokerhands>
  *

--- a/src/aa-pokerhands.h
+++ b/src/aa-pokerhands.h
@@ -1,7 +1,7 @@
 /*
  * aa-pokerhands.h
  *
- * Copyright 2011-2020 Andy <andy400-dev@yahoo.com>
+ * Copyright 2011-2020 Andy Alt <andy400-dev@yahoo.com>
  * This file is part of aa-pokerhands
  * <https://github.com/theimpossibleastronaut/aa-pokerhands>
  *
@@ -34,20 +34,15 @@
 /* use deckhandler library */
 #include "deckhandler/deckhandler.h"
 
-/* Number of hands to deal out */
-/* can be changed from the command line with -n [hands] */
-int RUN_COUNT;
-
 /* can be set on the command line with -v */
 /* Show all 52 cards after the deck has been shuffled */
-bool MORE_OUTPUT;
+extern bool MORE_OUTPUT;
 
 /* can be set on the command line with -s */
 /* Show the hand that was dealt */
-bool SHOW_HAND;
+extern bool SHOW_HAND;
 
-/* Leave set to 0, PLAY feature not finished */
-bool PLAY;
+extern bool PLAY;
 
 enum
 { PAIR, TWO_PAIR, THREE_OF_A_KIND, STRAIGHT, FLUSH,
@@ -65,6 +60,5 @@ typedef struct {
   st_card_info_dh card[HAND + 4];
 }st_hand;
 
-short int hand_suits[NUM_OF_SUITS];
 extern const int RANKS;
 extern bool *final;

--- a/src/aa-pokerhands.h
+++ b/src/aa-pokerhands.h
@@ -61,4 +61,3 @@ typedef struct {
 }st_hand;
 
 extern const int RANKS;
-extern bool *final;

--- a/src/functions.c
+++ b/src/functions.c
@@ -24,6 +24,7 @@
  */
 
 #include <stdlib.h>
+#include <pthread.h>
 #include "aa-pokerhands.h"
 #include "functions.h"
 
@@ -205,6 +206,9 @@ hand_eval (int *totals, const char **ranks, bool isHighStraight, bool *final)
 
   short eval = -1;
 
+  pthread_mutex_t lock;
+  pthread_mutex_lock(&lock);
+
 
   if (final[PAIR] && final[THREE_OF_A_KIND] != 1)
   {
@@ -253,6 +257,8 @@ hand_eval (int *totals, const char **ranks, bool isHighStraight, bool *final)
     eval = ROYAL_FLUSH;
     totals[ROYAL_FLUSH]++;
   }
+
+  pthread_mutex_unlock(&lock);
 
 
   if (SHOW_HAND)

--- a/src/functions.c
+++ b/src/functions.c
@@ -29,7 +29,7 @@
 #include "functions.h"
 
 void
-zero (int *hand_seq, bool *final, short int* hand_suits)
+zero (int *hand_seq, bool *final_hand, short int* hand_suits)
 {
   int i;
 
@@ -41,11 +41,11 @@ zero (int *hand_seq, bool *final, short int* hand_suits)
 
   /* set all array elements to 0 */
   for (i = 0; i < RANKS; ++i)
-    final[i] = 0;
+    final_hand[i] = 0;
 }
 
 void
-isStraight (int *hand_seq, bool *isHighStraight, bool *final)
+isStraight (int *hand_seq, bool *isHighStraight, bool *final_hand)
 {
   int k = 13;
 
@@ -70,7 +70,7 @@ isStraight (int *hand_seq, bool *isHighStraight, bool *final)
       state++;
       if (state == 4)
       {
-        final[STRAIGHT] = 1;
+        final_hand[STRAIGHT] = 1;
         if (k == 10)
         {
           /* printf("High Straight"); */
@@ -80,11 +80,11 @@ isStraight (int *hand_seq, bool *isHighStraight, bool *final)
     }
 
   }
-  while (--k && !final[STRAIGHT]);
+  while (--k && !final_hand[STRAIGHT]);
 }
 
 void
-isFlush (bool *final, short int* hand_suits)
+isFlush (bool *final_hand, short int* hand_suits)
 {
   int i;
   for (i = 0; i < NUM_OF_SUITS; ++i)
@@ -93,7 +93,7 @@ isFlush (bool *final, short int* hand_suits)
       break;
     else if (hand_suits[i] == HAND)
     {
-      final[FLUSH] = 1;
+      final_hand[FLUSH] = 1;
       break;
     }
   }
@@ -154,7 +154,7 @@ getopts (int argc, char *argv[], int *RUN_COUNT)
 }
 
 short int
-find_matches (int *hand_seq, bool *final)
+find_matches (int *hand_seq, bool *final_hand)
 {
   int face_val;
   short paired = 0;
@@ -165,20 +165,20 @@ find_matches (int *hand_seq, bool *final)
     {
       paired++;
     }
-    if (hand_seq[face_val] == 2 && !final[PAIR])
+    if (hand_seq[face_val] == 2 && !final_hand[PAIR])
     {
-      final[PAIR] = 1;
+      final_hand[PAIR] = 1;
     }
     else if (hand_seq[face_val] == 2)
     {
-      final[TWO_PAIR] = 1;
-      final[PAIR] = 0;
+      final_hand[TWO_PAIR] = 1;
+      final_hand[PAIR] = 0;
     }
     else if (hand_seq[face_val] == 3)
-      final[THREE_OF_A_KIND] = 1;
+      final_hand[THREE_OF_A_KIND] = 1;
     else if (hand_seq[face_val] == 4)
     {
-      final[FOUR_OF_A_KIND] = 1;
+      final_hand[FOUR_OF_A_KIND] = 1;
       break;
     }
     if (paired > 1)
@@ -201,7 +201,7 @@ show_totals (int *totals, const char **ranks, int RUN_COUNT)
 }
 
 void
-hand_eval (int *totals, const char **ranks, bool isHighStraight, bool *final)
+hand_eval (int *totals, const char **ranks, bool isHighStraight, bool *final_hand)
 {
 
   short eval = -1;
@@ -210,49 +210,49 @@ hand_eval (int *totals, const char **ranks, bool isHighStraight, bool *final)
   pthread_mutex_lock(&lock);
 
 
-  if (final[PAIR] && final[THREE_OF_A_KIND] != 1)
+  if (final_hand[PAIR] && final_hand[THREE_OF_A_KIND] != 1)
   {
     eval = PAIR;
     totals[PAIR]++;
   }
-  else if (final[TWO_PAIR])
+  else if (final_hand[TWO_PAIR])
   {
     eval = TWO_PAIR;
     totals[TWO_PAIR]++;
   }
-  else if (final[THREE_OF_A_KIND] && final[PAIR] != 1)
+  else if (final_hand[THREE_OF_A_KIND] && final_hand[PAIR] != 1)
   {
     eval = THREE_OF_A_KIND;
     totals[THREE_OF_A_KIND]++;
   }
-  else if (final[STRAIGHT] && final[FLUSH] != 1)
+  else if (final_hand[STRAIGHT] && final_hand[FLUSH] != 1)
   {
     eval = STRAIGHT;
     totals[STRAIGHT]++;
   }
-  else if (final[FLUSH] == 1 && final[STRAIGHT] != 1)
+  else if (final_hand[FLUSH] == 1 && final_hand[STRAIGHT] != 1)
   {
     eval = FLUSH;
     totals[FLUSH]++;
   }
-  else if (final[PAIR] && final[THREE_OF_A_KIND])
+  else if (final_hand[PAIR] && final_hand[THREE_OF_A_KIND])
   {
-    /* final[FULL_HOUSE] = 1; */
+    /* final_hand[FULL_HOUSE] = 1; */
     eval = FULL_HOUSE;
     totals[FULL_HOUSE]++;
   }
-  else if (final[FOUR_OF_A_KIND])
+  else if (final_hand[FOUR_OF_A_KIND])
   {
     eval = FOUR_OF_A_KIND;
     totals[FOUR_OF_A_KIND]++;
   }
-  else if (final[STRAIGHT] && final[FLUSH] && isHighStraight != 1)
+  else if (final_hand[STRAIGHT] && final_hand[FLUSH] && isHighStraight != 1)
   {
-    /* final[7] = 1;    */
+    /* final_hand[7] = 1;    */
     eval = STRAIGHT_FLUSH;
     totals[STRAIGHT_FLUSH]++;
   }
-  else if (final[STRAIGHT] && final[FLUSH] && isHighStraight)
+  else if (final_hand[STRAIGHT] && final_hand[FLUSH] && isHighStraight)
   {
     eval = ROYAL_FLUSH;
     totals[ROYAL_FLUSH]++;

--- a/src/functions.c
+++ b/src/functions.c
@@ -204,13 +204,6 @@ hand_eval (int *totals, const char **ranks, bool isHighStraight, bool *final_han
 
   short eval = -1;
 
-
-  // Having this lock causes the program to crash if 'final_hand' is declared
-  // outside the `while` loop in main_thread()
-  /* pthread_mutex_t lock;
-  pthread_mutex_lock(&lock); */
-
-
   if (final_hand[PAIR] && final_hand[THREE_OF_A_KIND] != 1)
   {
     eval = PAIR;
@@ -258,9 +251,6 @@ hand_eval (int *totals, const char **ranks, bool isHighStraight, bool *final_han
     eval = ROYAL_FLUSH;
     totals[ROYAL_FLUSH]++;
   }
-
-  /* pthread_mutex_unlock(&lock); */
-
 
   if (SHOW_HAND)
   {

--- a/src/functions.c
+++ b/src/functions.c
@@ -1,7 +1,7 @@
 /*
  * functions.c
  *
- * Copyright 2011-2020 Andy <andy400-dev@yahoo.com>
+ * Copyright 2011-2020 Andy Alt <andy400-dev@yahoo.com>
  * This file is part of aa-pokerhands
  * <https://github.com/theimpossibleastronaut/aa-pokerhands>
  *
@@ -28,7 +28,7 @@
 #include "functions.h"
 
 void
-zero (int *hand_seq, bool *final)
+zero (int *hand_seq, bool *final, short int* hand_suits)
 {
   int i;
 
@@ -83,7 +83,7 @@ isStraight (int *hand_seq, bool *isHighStraight, bool *final)
 }
 
 void
-isFlush (bool *final)
+isFlush (bool *final, short int* hand_suits)
 {
   int i;
   for (i = 0; i < NUM_OF_SUITS; ++i)
@@ -113,7 +113,7 @@ usage (const char *argv_one)
 }
 
 void
-getopts (int argc, char *argv[])
+getopts (int argc, char *argv[], int *RUN_COUNT)
 {
   /* fetch command line arguments */
   int i;
@@ -126,8 +126,8 @@ getopts (int argc, char *argv[])
         case 'n':
           if (i < argc - 1)
           {
-            RUN_COUNT = atoi (argv[i++ + 1]);
-            if (RUN_COUNT < 1)
+            *RUN_COUNT = atoi (argv[i++ + 1]);
+            if (*RUN_COUNT < 1)
               usage (argv[0]);
           }
           else
@@ -187,7 +187,7 @@ find_matches (int *hand_seq, bool *final)
 }
 
 void
-show_totals (int *totals, int run_count, const char **ranks)
+show_totals (int *totals, const char **ranks, int RUN_COUNT)
 {
   int n;
 
@@ -200,13 +200,8 @@ show_totals (int *totals, int run_count, const char **ranks)
 }
 
 void
-hand_eval (int *totals, int run_count, const char **ranks, bool isHighStraight, bool *final)
+hand_eval (int *totals, const char **ranks, bool isHighStraight, bool *final)
 {
-  int i;
-
-  if (run_count == 1)
-    for (i = 0; i < RANKS; i++)
-      totals[i] = 0;
 
   short eval = -1;
 

--- a/src/functions.c
+++ b/src/functions.c
@@ -41,7 +41,7 @@ init (int *hand_seq, bool *final_hand, short int* hand_suits)
 
   /* set all array elements to 0 */
   for (i = 0; i < RANKS; i++)
-    final_hand[i] = 0;
+    final_hand[i] = false;
 }
 
 void
@@ -83,8 +83,8 @@ isStraight (int *hand_seq, bool *isHighStraight, bool *final_hand)
   while (--k && !final_hand[STRAIGHT]);
 }
 
-void
-isFlush (bool *final_hand, short int* hand_suits)
+bool
+is_flush (short int* hand_suits)
 {
   int i;
   for (i = 0; i < NUM_OF_SUITS; ++i)
@@ -92,11 +92,9 @@ isFlush (bool *final_hand, short int* hand_suits)
     if (hand_suits[i] != HAND && hand_suits[i])
       break;
     else if (hand_suits[i] == HAND)
-    {
-      final_hand[FLUSH] = 1;
-      break;
-    }
+      return true;
   }
+  return false;
 }
 
 static void
@@ -206,8 +204,11 @@ hand_eval (int *totals, const char **ranks, bool isHighStraight, bool *final_han
 
   short eval = -1;
 
-  pthread_mutex_t lock;
-  pthread_mutex_lock(&lock);
+
+  // Having this lock causes the program to crash if 'final_hand' is declared
+  // outside the `while` loop in main_thread()
+  /* pthread_mutex_t lock;
+  pthread_mutex_lock(&lock); */
 
 
   if (final_hand[PAIR] && final_hand[THREE_OF_A_KIND] != 1)
@@ -258,7 +259,7 @@ hand_eval (int *totals, const char **ranks, bool isHighStraight, bool *final_han
     totals[ROYAL_FLUSH]++;
   }
 
-  pthread_mutex_unlock(&lock);
+  /* pthread_mutex_unlock(&lock); */
 
 
   if (SHOW_HAND)

--- a/src/functions.c
+++ b/src/functions.c
@@ -29,18 +29,18 @@
 #include "functions.h"
 
 void
-zero (int *hand_seq, bool *final_hand, short int* hand_suits)
+init (int *hand_seq, bool *final_hand, short int* hand_suits)
 {
   int i;
 
-  for (i = 0; i < ACE_HIGH; ++i)
+  for (i = 0; i < ACE_HIGH; i++)
     hand_seq[i] = 0;
 
-  for (i = 0; i < NUM_OF_SUITS; ++i)
+  for (i = 0; i < NUM_OF_SUITS; i++)
     hand_suits[i] = 0;
 
   /* set all array elements to 0 */
-  for (i = 0; i < RANKS; ++i)
+  for (i = 0; i < RANKS; i++)
     final_hand[i] = 0;
 }
 

--- a/src/functions.h
+++ b/src/functions.h
@@ -23,7 +23,7 @@
  *
  */
 
-void zero (int *hand_seq, bool *final, short int* hand_suits);
+void init (int *hand_seq, bool *final, short int* hand_suits);
 
 void isStraight (int *hand_seq, bool *isHighStraight, bool *final);
 

--- a/src/functions.h
+++ b/src/functions.h
@@ -27,7 +27,7 @@ void init (int *hand_seq, bool *final, short int* hand_suits);
 
 void isStraight (int *hand_seq, bool *isHighStraight, bool *final);
 
-void isFlush (bool *final, short int* hand_suits);
+bool is_flush (short int* hand_suits);
 
 void getopts (int argc, char *argv[], int *RUN_COUNT);
 

--- a/src/functions.h
+++ b/src/functions.h
@@ -1,7 +1,7 @@
 /*
  * functions.c
  *
- * Copyright 2011-2020 Andy <andy400-dev@yahoo.com>
+ * Copyright 2011-2020 Andy Alt <andy400-dev@yahoo.com>
  * This file is part of aa-pokerhands
  * <https://github.com/theimpossibleastronaut/aa-pokerhands>
  *
@@ -23,17 +23,17 @@
  *
  */
 
-void zero (int *hand_seq, bool *final);
+void zero (int *hand_seq, bool *final, short int* hand_suits);
 
 void isStraight (int *hand_seq, bool *isHighStraight, bool *final);
 
-void isFlush (bool *final);
+void isFlush (bool *final, short int* hand_suits);
 
-void getopts (int argc, char *argv[]);
+void getopts (int argc, char *argv[], int *RUN_COUNT);
 
 short int find_matches (int *hand_seq, bool *final);
 
-void hand_eval (int *totals, int run_count, const char **ranks, bool isHighStraight, bool *final);
+void hand_eval (int *totals, const char **ranks, bool isHighStraight, bool *final);
 
 void
-show_totals (int *totals, int run_count, const char **ranks);
+show_totals (int *totals, const char **ranks, int RUN_COUNT);

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,9 @@
 src = ['aa-pokerhands.c', 'functions.c']
 dep = 'deckhandler'
 dep_target = static_library(dep, join_paths(dep, dep + '.c'))
-executable('pokerhands', src, link_with : dep_target)
+
+extra_args = ['-fno-common']
+executable('pokerhands', src, c_args : extra_args, link_with : dep_target, dependencies : dependency('threads'))
 
 conf = configuration_data()
 conf.set('VERSION', meson.project_version())

--- a/src/meson.build
+++ b/src/meson.build
@@ -3,7 +3,7 @@ dep = 'deckhandler'
 dep_target = static_library(dep, join_paths(dep, dep + '.c'))
 
 extra_args = ['-fno-common']
-executable('pokerhands', src, c_args : extra_args, link_with : dep_target, dependencies : dependency('threads'))
+executable('pokerhands', src, c_args : extra_args, link_with : dep_target)
 
 conf = configuration_data()
 conf.set('VERSION', meson.project_version())


### PR DESCRIPTION
I timed using `-n 1000000` and it comes to about 15 seconds after adding code for multi-threading. Before, it was about 2 seconds. So... not sure why the threading would slow things down so significantly....

This output below is just a run through valgrind showing no leaks apparently.

```
andy@oceanus:~/src/aa-pokerhands/builddir$ valgrind --leak-check=full src/pokerhands -n 100000
==25001== Memcheck, a memory error detector
==25001== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==25001== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==25001== Command: src/pokerhands -n 100000
==25001== 
Out of 25000 hands:

                Pair:     10625
            Two Pair:      1161
     Three-of-a-Kind:       498
            Straight:        94
               Flush:        56
          Full House:        41
      Four-of-a-Kind:         2
      Straight Flush:         0
         Royal Flush:         0
Out of 25000 hands:

                Pair:     10526
            Two Pair:      1143
     Three-of-a-Kind:       543
            Straight:       108
               Flush:        47
          Full House:        40
      Four-of-a-Kind:         5
      Straight Flush:         1
         Royal Flush:         0
Out of 25000 hands:

                Pair:     10611
            Two Pair:      1101
     Three-of-a-Kind:       492
            Straight:        89
               Flush:        36
          Full House:        40
      Four-of-a-Kind:         5
      Straight Flush:         0
         Royal Flush:         0
Joined with thread 0; returned value was (null)
Out of 25000 hands:

                Pair:     10607
            Two Pair:      1251
     Three-of-a-Kind:       539
            Straight:        75
               Flush:        51
          Full House:        32
      Four-of-a-Kind:         6
      Straight Flush:         1
         Royal Flush:         0
Joined with thread 1; returned value was (null)
Joined with thread 2; returned value was (null)
Joined with thread 3; returned value was (null)

==25001== 
==25001== HEAP SUMMARY:
==25001==     in use at exit: 0 bytes in 0 blocks
==25001==   total heap usage: 6 allocs, 6 frees, 2,240 bytes allocated
==25001== 
==25001== All heap blocks were freed -- no leaks are possible
==25001== 
==25001== For counts of detected and suppressed errors, rerun with: -v
==25001== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```